### PR TITLE
A707082877755959 accr validation err msg

### DIFF
--- a/openregistry/lots/core/validation.py
+++ b/openregistry/lots/core/validation.py
@@ -16,10 +16,10 @@ def validate_lot_data(request, **kwargs):
     update_logging_context(request, {'lot_id': '__new__'})
     data = validate_json_data(request)
     model = request.lot_from_data(data, create=False)
-    validate_accreditations(request, model)
+    validate_accreditations(request, model, 'lot')
 
     data = validate_data(request, model, "lot", data=data)
-    validate_t_accreditation(request, data)
+    validate_t_accreditation(request, data, 'lot')
 
 
 def validate_post_lot_role(request, error_handler, **kwargs):


### PR DESCRIPTION
Update call of accreditation validation functions

* Add resource_type as argument to function for proper error
message formatting

### Depends on:

- https://github.com/openprocurement/openprocurement.api/pull/356